### PR TITLE
Fix predicate selector

### DIFF
--- a/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
+++ b/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
@@ -38,8 +38,8 @@ export default function PredicateSelector({ id }) {
     const objectCategories = getCategories(objectNode.categories);
 
     // get hierarchies of all involved node categories
-    const subjectNodeCategoryHierarchy = subjectCategories.flatMap((subjectCategory) => biolink.hierarchies[subjectCategory]);
-    const objectNodeCategoryHierarchy = objectCategories.flatMap((objectCategory) => biolink.hierarchies[objectCategory]);
+    const subjectNodeCategoryHierarchy = subjectCategories.flatMap((subjectCategory) => biolink.ancestorsMap[subjectCategory]);
+    const objectNodeCategoryHierarchy = objectCategories.flatMap((objectCategory) => biolink.ancestorsMap[objectCategory]);
 
     // if we get categories back that aren't in the biolink model
     if (!subjectNodeCategoryHierarchy || !objectNodeCategoryHierarchy) {


### PR DESCRIPTION
The predicate selector now considers the subject's/object's (and their ancestor's) mixins. It no longer considers the subject's/object's descendant classes