### PR TITLE
Bug uichanges

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -4,7 +4,7 @@ import './footer.css';
 
 export default function Footer() {
   return (
-    <div className="footer">
+    <footer>
       <p>
         ROBOKOP is a joint creation of <a href="http://www.renci.org" target="_blank" rel="noreferrer">RENCI</a>{' '}
         and <a href="http://www.covar.com" target="_blank" rel="noreferrer">CoVar LLC</a>. Early development was{' '}
@@ -14,6 +14,6 @@ export default function Footer() {
         <a href="https://datascience.nih.gov/about/odss" target="_blank" rel="noreferrer">ODSS</a>.{' '}
         <Link to="/termsofservice">Terms of Service</Link>.
       </p>
-    </div>
+    </footer>
   );
 }

--- a/src/components/footer/footer.css
+++ b/src/components/footer/footer.css
@@ -1,11 +1,12 @@
-.footer {
+footer {
     position: absolute;
     bottom: 0;
     width: 100%;
+    height: auto;
     color: #5e5e5e;
     background-color: #f5f7fa;
 }
-.footer p {
+footer p {
     font-size: 1.25em;
     margin-top: 5px;
     text-align: center;

--- a/src/pages/answer/leftDrawer/leftDrawer.css
+++ b/src/pages/answer/leftDrawer/leftDrawer.css
@@ -3,4 +3,5 @@
     width: 220px;
     position: absolute;
     margin-top: 14px;
+    z-index: -1;
 }

--- a/src/pages/answer/resultsTable/ResultExplorer.jsx
+++ b/src/pages/answer/resultsTable/ResultExplorer.jsx
@@ -350,7 +350,7 @@ export default function ResultExplorer({ answerStore }) {
       elevation={3}
     >
       <h5 className="cardLabel">Answer Explorer</h5>
-      { Boolean(answerStore.showNodePruneSlider)  && (
+      { Boolean(answerStore.showNodePruneSlider) && (
         <Box width={200} id="nodeNumSlider">
           <Slider
             value={numTrimmedNodes}

--- a/src/pages/answer/resultsTable/ResultExplorer.jsx
+++ b/src/pages/answer/resultsTable/ResultExplorer.jsx
@@ -350,7 +350,7 @@ export default function ResultExplorer({ answerStore }) {
       elevation={3}
     >
       <h5 className="cardLabel">Answer Explorer</h5>
-      {answerStore.showNodePruneSlider && (
+      { Boolean(answerStore.showNodePruneSlider)  && (
         <Box width={200} id="nodeNumSlider">
           <Slider
             value={numTrimmedNodes}


### PR DESCRIPTION
This PR fixes two bugs:
- 0 was showing up when answer explorer was expanded on the Answer page
- On the answer page, footer stayed behind the left drawer. 

An update to us html's semantic <footer> tag instead of <div> has also been made.